### PR TITLE
Add special TTI settings

### DIFF
--- a/compiler/compile.py
+++ b/compiler/compile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 from ply import lex
-from dna.base import DNAStorage
+from dna.base import DNAStorage, DNASettings
 from dna.components import DNARoot
 from dna.parser.tokens import *
 
@@ -25,12 +25,18 @@ parser.add_argument('--path', '-p',
                     help='Add this path to search path (font loading only).')
 parser.add_argument('--encoding', '-e', default='latin-1',
                     help='Encoding (useful for latin chars rendering).')
+parser.add_argument('--special', '-s', default='none',
+                    help='Special compilation (none/tti)')
 parser.add_argument('filenames', nargs='+',
                     help='The raw input file(s). Accepts * as wildcard.')
 args = parser.parse_args()
 
 if args.path:
     getModelPath().appendDirectory(args.path)
+
+if args.special and args.special == 'tti':
+    print 'Using TTI compiler settings.'
+    DNASettings.FlatBuildingWidth = 100
 
 reload(sys)
 sys.setdefaultencoding(args.encoding)

--- a/compiler/dna/base/DNASettings.py
+++ b/compiler/dna/base/DNASettings.py
@@ -1,0 +1,1 @@
+FlatBuildingWidth = 10

--- a/compiler/dna/components/DNAFlatBuilding.py
+++ b/compiler/dna/components/DNAFlatBuilding.py
@@ -1,6 +1,6 @@
 from DNANode import DNANode
+from dna.base import DNASettings
 from dna.base.DNAPacker import *
-
 
 class DNAFlatBuilding(DNANode):
     COMPONENT_CODE = 9
@@ -19,7 +19,7 @@ class DNAFlatBuilding(DNANode):
     def traverse(self, recursive=True, verbose=False):
         packer = DNANode.traverse(self, recursive=False, verbose=verbose)
         packer.name = 'DNAFlatBuilding'  # Override the name for debugging.
-        packer.pack('width', self.width * 10, UINT16)
+        packer.pack('width', self.width * DNASettings.FlatBuildingWidth, UINT16)
         packer.pack('has door', self.hasDoor, BOOLEAN)
 
         if recursive:


### PR DESCRIPTION
This fixes DNAFlatBuildings for usage with the TTI parser.

Usage is simple: compile.py --special tti