### PR TITLE
Remove unused Panda3D import

### DIFF
--- a/compiler/dna/components/DNASignBaseline.py
+++ b/compiler/dna/components/DNASignBaseline.py
@@ -2,7 +2,6 @@ import math
 import sys
 from dna.base.DNAPacker import *
 from DNANode import DNANode
-from panda3d.core import *
 
 
 class DNASignBaseline(DNANode):


### PR DESCRIPTION
The compiler does not rely on Panda3D anymore, however the unit tests still require it.