### PR TITLE
Remove unused Panda3D import in cxx-signs branch

### DIFF
--- a/compiler/dna/components/DNASignBaseline.py
+++ b/compiler/dna/components/DNASignBaseline.py
@@ -2,7 +2,6 @@ import math
 import sys
 from dna.base.DNAPacker import *
 from DNANode import DNANode
-from panda3d.core import *
 
 
 class DNASignBaseline(DNANode):


### PR DESCRIPTION
The compiler on the cxx-signs branch no longer relies on Panda3D, however the unit tests still require it.