### PR TITLE
fix issues with compiling on mac

### DIFF
--- a/src/base/DNAStorage.cxx
+++ b/src/base/DNAStorage.cxx
@@ -642,7 +642,7 @@ void DNAStorage::write_dna(std::ostream& out)
     }
     
     // Nodes
-    typedef std::map<std::string, std::vector<string_vec_t>> str2strstr_t; // {filename: ((code, search), (code, search), ...)}
+    typedef std::map<std::string, std::vector<string_vec_t> > str2strstr_t; // {filename: ((code, search), (code, search), ...)}
     str2strstr_t _models;
     for (nodes_t::iterator it = m_nodes.begin(); it != m_nodes.end(); ++it)
     {

--- a/src/base/DNAStorage.h
+++ b/src/base/DNAStorage.h
@@ -16,7 +16,7 @@ typedef std::vector<std::string> string_vec_t;
 typedef std::map<std::string, string_vec_t> nodes_t;
 typedef std::vector<DNASuitPoint*> suit_point_vec_t;
 typedef std::vector<DNAVisGroup*> visgroup_vec_t;
-typedef std::map<point_index_t, std::vector<DNASuitEdge*>> suit_edge_map_t;
+typedef std::map<point_index_t, std::vector<DNASuitEdge*> > suit_edge_map_t;
 typedef std::map<std::string, PT(TextFont)> font_map_t;
 typedef std::map<std::string, std::string> font_filename_map_t;
 typedef std::map<block_number_t, std::string> block_string_map_t;


### PR DESCRIPTION
Tested on 10.10 and 10.11 compiling with a panda3d built with correct flags (export CXXFLAGS="-std=c++11") successfully built lipandadna for mac